### PR TITLE
hotfix/asset_name - Github Action: Upload Artifact to Release 

### DIFF
--- a/.github/workflows/docker-build-publish-merged.yml
+++ b/.github/workflows/docker-build-publish-merged.yml
@@ -137,3 +137,4 @@ jobs:
           file: ${{steps.helm-package.outputs.helm_package}}
           tag: ${{steps.increment-semver-patch.outputs.version}}
           file_glob: false
+          asset_name: ${{steps.helm-package.outputs.helm_package}}


### PR DESCRIPTION
adding asset_name because its required if the `fileglob` is false